### PR TITLE
HHH-12323 fix access to Statistics over JMX

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/stat/CacheableDataStatistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/CacheableDataStatistics.java
@@ -6,10 +6,12 @@
  */
 package org.hibernate.stat;
 
+import java.io.Serializable;
+
 /**
  * @author Steve Ebersole
  */
-public interface CacheableDataStatistics {
+public interface CacheableDataStatistics extends Serializable {
 	long NOT_CACHED_COUNT = Long.MIN_VALUE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/AbstractCacheableDataStatistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/AbstractCacheableDataStatistics.java
@@ -12,14 +12,13 @@ import java.util.function.Supplier;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.stat.CacheableDataStatistics;
 
-import org.jboss.logging.Logger;
-
 /**
  * @author Steve Ebersole
  */
 public abstract class AbstractCacheableDataStatistics implements CacheableDataStatistics {
-	private static final Logger log = Logger.getLogger( AbstractCacheableDataStatistics.class );
-
+	// This magic number allow pre-5.3.7 releases RMI compatibility (which includes a JBoss Logger instance)	
+	private static final long serialVersionUID = 1417304055641145372L;
+	
 	private final String cacheRegionName;
 	private final LongAdder cacheHitCount;
 	private final LongAdder cacheMissCount;

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/QueryStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/QueryStatisticsImpl.java
@@ -14,8 +14,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.hibernate.stat.QueryStatistics;
 
-import org.jboss.logging.Logger;
-
 /**
  * Query statistics (HQL and SQL)
  * <p/>
@@ -24,8 +22,9 @@ import org.jboss.logging.Logger;
  * @author Alex Snaps
  */
 public class QueryStatisticsImpl implements QueryStatistics {
-	private static final Logger log = Logger.getLogger( QueryStatisticsImpl.class );
-
+	// This magic number allow pre-5.3.7 releases RMI compatibility (which includes a JBoss Logger instance)	
+	private static final long serialVersionUID = 8569182022705792772L;
+	
 	private final String query;
 
 	private final LongAdder cacheHitCount = new LongAdder();
@@ -138,8 +137,6 @@ public class QueryStatisticsImpl implements QueryStatistics {
 	 * @param time time taken
 	 */
 	void executed(long rows, long time) {
-		log.tracef( "QueryStatistics - query executed : %s", query );
-
 		// read lock is enough, concurrent updates are supported by the underlying type AtomicLong
 		// this only guards executed(long, long) to be called, when another thread is executing getExecutionAvgTime()
 		readLock.lock();
@@ -157,20 +154,14 @@ public class QueryStatisticsImpl implements QueryStatistics {
 	}
 
 	void incrementCacheHitCount() {
-		log.tracef( "QueryStatistics - cache hit : %s", query );
-
 		cacheHitCount.increment();
 	}
 
 	void incrementCacheMissCount() {
-		log.tracef( "QueryStatistics - cache miss : %s", query );
-
 		cacheMissCount.increment();
 	}
 
 	void incrementCachePutCount() {
-		log.tracef( "QueryStatistics - cache put : %s", query );
-
 		cachePutCount.increment();
 	}
 


### PR DESCRIPTION
Access to CollectionStatistics, EntityStatistics and NaturalIdStatistics through JMX is broken because their new parent interface CacheableDataStatistics is not serializable.

### Test case
- import the sample Spring Boot application from https://github.com/icidel/spring-boot-jmx-export-of-hibernate-statistics as an Eclipse project (or your favorite)
- execute the map class "Application"
- execute jconsole from you JDK bin folder and connect to the running application
- open the MBean tab
- access the Hibernate/Statistics MBean "operations" panel
- run the getEntityStatistics opération with "com.example.hibernatestatsdemo.Customer" as entityName argument


This test case is **OK** if the pom.xml file references Hibernate 5.2.x and earlier: entity statistics are returned successfully.

This test case is **KO** if the pom.xml file references Hibernate 5.3.0 to 5.3.5: an unmarshalling exception is raised because the EntityStatistics interface is not fully serializable.

This simple patch correct this bug.
